### PR TITLE
[#5815290] Fix error if last expression is the result of a square root

### DIFF
--- a/src/math/expression_manipulation.coffee
+++ b/src/math/expression_manipulation.coffee
@@ -165,7 +165,7 @@ class_mixer(Square)
 class AppendDecimal extends ExpressionManipulation
   # @destructive
   doAppendD: (expression, expression_position)->
-    last = expression.last()
+    last = if expression.last? then expression.last()
 
     if typeof last == 'undefined'
       new_last = @comps.build_number(value: 0)


### PR DESCRIPTION
For some reason roots don't have `.last()` on their expression. There might be a
better fix.

As prophesied, this is the continuation of #4 because of some good in situ QA.
